### PR TITLE
small EAS code speedup

### DIFF
--- a/ush/enspost_make_easfracqpf_combo.py
+++ b/ush/enspost_make_easfracqpf_combo.py
@@ -26,6 +26,9 @@ from functools import partial
 
 # import fortranfile as F
 
+# CRITICAL: Prevent numpy/scipy from fighting for threads inside multiprocessing
+os.environ["OMP_NUM_THREADS"] = "1"
+
 def optimized_wgrib2(txtfile):
     """
     Reads grid dimensions and data from a text file more efficiently.


### PR DESCRIPTION
Adds an OMP_NUM_THREADS=1 line into QPF EAS ush script
 
 without this fix (in v1 real time system):
 
 202512291200             eas_gen_f09                   233775501           SUCCEEDED                   0         1         622.0
202512291200             eas_gen_f12                   233777726           SUCCEEDED                   0         1         877.0
202512291200             eas_gen_f24                   233784478           SUCCEEDED                   0         1        1260.0

with this fix (in v2 system just with this fix):

202512291200             eas_gen_f09                   233775550           SUCCEEDED                   0         1         615.0
202512291200             eas_gen_f12                   233777107           SUCCEEDED                   0         1         823.0
202512291200             eas_gen_f24                   233784492           SUCCEEDED                   0         1        1175.0